### PR TITLE
adjust security group on redis to allow all connections inside the vpc

### DIFF
--- a/src/stack/redis.ts
+++ b/src/stack/redis.ts
@@ -22,7 +22,15 @@ class RedisCluster extends cdk.Construct {
     });
 
     // The security group that defines network level access to the cluster
-    const securityGroup = new ec2.SecurityGroup(this, `${id}-security-group`, { vpc: targetVpc });
+    const securityGroup = new ec2.SecurityGroup(this, `${id}-security-group`, { 
+      vpc: targetVpc, 
+    });
+
+    securityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.allTraffic(),
+      'Allow all connections to redis from inside the VPC'
+    );
 
     // The cluster resource itself.
     this.cluster = new elasticache.CfnCacheCluster(this, `${id}-cluster`, {


### PR DESCRIPTION
It looks like there are some issues with ECS containers connecting to redis in private subnet as there are no security rules.

This allows all connections, which should be limited to just subnets inside the VPC.

This might require a bit of tunning to define the subnet explicitly.