### PR TITLE
add DB_PASS to env

### DIFF
--- a/src/stack/service.ts
+++ b/src/stack/service.ts
@@ -128,6 +128,7 @@ export default class Service extends cdk.Stack {
       DB_HOST: CLUSTER_VAULT.secretValueFromJson('host').toString(),
       DB_PORT: CLUSTER_VAULT.secretValueFromJson('port').toString(),
       DB_USER: CLUSTER_VAULT.secretValueFromJson('username').toString(),
+      DB_PASS: CLUSTER_VAULT.secretValueFromJson('password').toString(),
       REDIS_HOST: this.redis?.cluster?.attrRedisEndpointAddress,
       REDIS_PORT: this.redis?.cluster?.attrRedisEndpointPort,
       MQ_URL: this.mq?.queueUrl,


### PR DESCRIPTION
This adds the missing `DB_PASS` from the auto created aurora vault to the env vars in the task definition.

@jpablo1286 please confirm with customer. @klebertertulino please review before we merge.